### PR TITLE
Home page colours and logo

### DIFF
--- a/app/src/main/java/com/example/dontpushmybuttons/MainActivity.kt
+++ b/app/src/main/java/com/example/dontpushmybuttons/MainActivity.kt
@@ -460,6 +460,14 @@ fun FixedGrid(
     }
     Column(modifier = Modifier.fillMaxSize()) {
         if (!isGameRunning && !gameOver) {
+            AppLogo(
+                modifier = Modifier
+                    .height(600.dp)
+                    .padding(vertical = 0.dp)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
             Button(
                 onClick = { startNewGame() },
                 colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/dontpushmybuttons/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/dontpushmybuttons/ui/theme/Theme.kt
@@ -13,19 +13,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
-    primary = Purple80,
-    secondary = PurpleGrey80,
-    tertiary = Pink80,
-    background = Color.Black,
+    primary = Color(0xFF008080),
+    secondary = Color(0xFF008080),
+    tertiary = Color(0xFF00CED1),
+    background = Color.DarkGray,
     surface = Color(0xFF121212),
     onBackground = Color.White,
     onSurface = Color.White
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = Purple40,
-    secondary = PurpleGrey40,
-    tertiary = Pink40,
+    primary = Color(0xFF00CED1),
+    secondary = Color(0xFF00CED1),
+    tertiary = Color(0xFF00CED1),
     background = Color.White,
     surface = Color(0xFFF5F5F5),
     onBackground = Color.Black,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3e067ac7-3d00-47c2-93fa-8f7ec6f4fb70)


![image](https://github.com/user-attachments/assets/3cd16e43-5eda-4642-bd38-800039429554)

Changed Dark Mode background to Dark Gray instead of Black.
Moved logo to center and made larger to fill screen.
Changed button colours to better match the theme.